### PR TITLE
x123 reorder index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,35 +9,6 @@ Use the navigation menu on the left, the :material-menu: icon at the top left
 on mobile, and the navigation links at the bottom of the page in the footer to
 get around.
 
-# Quick Start
-
-## Skippers
-
-- [Information for Skippers](skipper-info.md)
-- [Pre-Departure Checklist](pre-departure-checklist.md)
-- [Skovshoved Harbour Manoevres](skovshoved-manoeuvres.md)
-- [After-Sailing Checklist](after-sailing-checklist.md)
-- [Skipper Approval & Training](skipper-approval-training.md)
-- [Equipment Defects](equipment-defects.md)
-
-## Safety
-
-- [In Case of Injury](in-case-of-injury.md)
-- [General Safety Information](kdy-safety.md)
-- [VHF Radio](vhf-radio.md)
-
-## DS37 Manual
-
-- [About the DS37](the-ds37.md)
-- [Safety on the DS37](ds37-safety.md)
-- [Sail Handling](sail-handling.md)
-- [Manoeuvres](manoeuvres.md)
-- [Match Race Crew Positions](match-race-crew-positions.md)
-
-## Seasons
-
-- [2025 Sailing Season](seasons/2025.md)
-
 # Contributing
 
 Contributions to these documents are welcome and entirely volunteer-driven.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ markdown_extensions:
       baselevel: 2
 nav:
   - 'Getting Started': index.md
+  - 'Seasons':
+    - '2025 Sailing Season': seasons/2025.md
   - 'Skippers':
     - 'Information for Skippers': skipper-info.md
     - 'Pre-Departure Checklist': pre-departure-checklist.md
@@ -53,8 +55,6 @@ nav:
     - 'After-Sailing Checklist': after-sailing-checklist.md
     - 'Skipper Approval & Training': skipper-approval-training.md
     - 'Equipment Defects': equipment-defects.md
-  - 'Seasons':
-    - '2025 Sailing Season': seasons/2025.md
   - 'Safety':
     - 'In Case of Injury': in-case-of-injury.md
     - 'General Safety Information': kdy-safety.md


### PR DESCRIPTION
- remove "quick start" section, as it's duplicative and already handled in the table of contents
- reorder the Seasons section to near the top of the ToC